### PR TITLE
Only check Spider-vehicles on equipment

### DIFF
--- a/script/spidertron.lua
+++ b/script/spidertron.lua
@@ -65,6 +65,7 @@ local reevaluate = function(event)
   
   
     local opened = player.opened
+    if not (opened and opened.object_name == "LuaEntity" and opened.type == "spider-vehicle") then return end
     if not (opened and opened.valid) then return end
 
     adjust_spidertron(opened)


### PR DESCRIPTION
This fixes bug where any entity which contained an equipment grid (such as modded entities or grids added to base vehicles) was running the "adjust_spidertron" function and causing errors on non-spider entities.